### PR TITLE
fix tailwind config error, use typescript

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,6 @@
-/** @type {import('tailwindcss').Config} */
+import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
+
 export default {
   darkMode: "selector",
   content: [
@@ -74,5 +76,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
-};
+  plugins: [animatePlugin],
+} satisfies Config;


### PR DESCRIPTION
<!-- Describe your PR here. -->
Use Typescript for Tailwind config for broader compatibility.

Some versions of Node 22 and 23 break due to the package having type module. Most versions of Node know how to handle this, but it's arguably more correct to use import and proper types anyway.

Reference post in Discord: https://discord.com/channels/1019350475847499849/1314403372006379561/1317536304929701949

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
